### PR TITLE
fix: error read keyname

### DIFF
--- a/signer/opsigneradapter/signer_adapter.go
+++ b/signer/opsigneradapter/signer_adapter.go
@@ -13,6 +13,10 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
+const (
+	FieldKeyName = "KeyName"
+)
+
 type SignerAdapter struct {
 	opSigner opsignerprovider.SignatureProvider
 	ctx      context.Context
@@ -43,7 +47,7 @@ func NewSignerAdapterFromConfig(ctx context.Context, logger signercommon.Logger,
 	if err != nil {
 		return nil, fmt.Errorf("error creating opSignerProvider. Err: %w", err)
 	}
-	keyName, err := cfg.Get("KeyName")
+	keyName, err := cfg.Get(FieldKeyName)
 	if err != nil {
 		return nil, fmt.Errorf("error getting keyName from config. Err: %w", err)
 	}

--- a/signer/types/config.go
+++ b/signer/types/config.go
@@ -1,6 +1,9 @@
 package types
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 type SignMethod string
 
@@ -31,7 +34,10 @@ type SignerConfig struct {
 func (c SignerConfig) Get(key string) (string, error) {
 	v, ok := c.Config[key]
 	if !ok {
-		return "", fmt.Errorf("key %s not found", key)
+		v, ok = c.Config[strings.ToLower(key)]
+		if !ok {
+			return "", fmt.Errorf("key %s not found", key)
+		}
 	}
 	s, ok := v.(string)
 	if !ok {

--- a/version.go
+++ b/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	Version = "v0.0.5"
+	Version = "v0.0.6"
 )
 
 // PrintVersion prints version info into the provided io.Writer.


### PR DESCRIPTION
## Description

The extra fields are read as lower case and fails to create the GPC KMS config

Fixes # (issue)
