### PR TITLE
feat: increase unit test for AWS

### DIFF
--- a/signer/factory_test.go
+++ b/signer/factory_test.go
@@ -175,6 +175,18 @@ func TestNewSignerFromConfigFile(t *testing.T) {
 			expectedConfigString: "SignerConfig:Method: mock\n Config[privatekey]: 0xa574853f4757bfdcbb59b03635324463750b27e16df897f3d00dc6bef2997ae0\n",
 			expectedSignerString: "MockSign{name:mock privateKey, mode:PrivateKey, initialized: false}",
 		},
+		{
+			name: "AWS",
+			configFileContent: []string{`
+			[Signer]
+			Method = "AWS"
+			KeyName = "a47c263b-6575-4835-8721-af0bbb97XXXX"
+			`,
+				`Signer={ Method="AWS", KeyName="a47c263b-6575-4835-8721-af0bbb97XXXX"}`,
+			},
+			expectedConfigString: "SignerConfig:Method: AWS\n Config[keyname]: a47c263b-6575-4835-8721-af0bbb97XXXX\n",
+			expectedSignerString: "signerAdapter: op_signer_adapter AWS/a47c263b-6575-4835-8721-af0bbb97XXXX",
+		},
 	}
 
 	for _, tc := range testcases {

--- a/signer/opsigneradapter/signer_adapter.go
+++ b/signer/opsigneradapter/signer_adapter.go
@@ -18,23 +18,26 @@ const (
 )
 
 type SignerAdapter struct {
-	opSigner opsignerprovider.SignatureProvider
-	ctx      context.Context
-	logger   signercommon.Logger
-	keyName  string
-	chainID  uint64
+	opSigner       opsignerprovider.SignatureProvider
+	opTypeProvider opsignerprovider.ProviderType
+	ctx            context.Context
+	logger         signercommon.Logger
+	keyName        string
+	chainID        uint64
 }
 
 var _ gosignertypes.Signer = (*SignerAdapter)(nil)
 
 func NewSignerAdapter(ctx context.Context, logger signercommon.Logger, opSigner opsignerprovider.SignatureProvider,
+	opTypeProvider opsignerprovider.ProviderType,
 	keyName string, chainID uint64) *SignerAdapter {
 	return &SignerAdapter{
-		opSigner: opSigner,
-		ctx:      ctx,
-		logger:   logger,
-		keyName:  keyName,
-		chainID:  chainID,
+		opSigner:       opSigner,
+		opTypeProvider: opTypeProvider,
+		ctx:            ctx,
+		logger:         logger,
+		keyName:        keyName,
+		chainID:        chainID,
 	}
 }
 
@@ -51,7 +54,7 @@ func NewSignerAdapterFromConfig(ctx context.Context, logger signercommon.Logger,
 	if err != nil {
 		return nil, fmt.Errorf("error getting keyName from config. Err: %w", err)
 	}
-	return NewSignerAdapter(ctx, logger, opSigner, keyName, chainID), nil
+	return NewSignerAdapter(ctx, logger, opSigner, opConfig.ProviderType, keyName, chainID), nil
 }
 
 func (s *SignerAdapter) Initialize(context.Context) error {
@@ -76,7 +79,7 @@ func convertPublicKeyToAddress(publicKey []byte) common.Address {
 }
 
 func (s *SignerAdapter) String() string {
-	return "op_signer_adapter"
+	return "signerAdapter: op_signer_adapter " + string(s.opTypeProvider) + "/" + s.keyName
 }
 
 func (s *SignerAdapter) SignHash(ctx context.Context, hash common.Hash) ([]byte, error) {


### PR DESCRIPTION
## Description

- Add proper description for GCP and AWS signers. Example `signerAdapter: op_signer_adapter AWS/a47c263b-6575-4835-8721-af0bbb97XXXX`
- 

